### PR TITLE
Add Voter Count to Output in get_text Method

### DIFF
--- a/ppbot/game.py
+++ b/ppbot/game.py
@@ -64,13 +64,14 @@ class Game:
             self.text, self._initiator_str(self.initiator)
         )
         if self.votes:
+            vote_count = len(self.votes)
             votes_str = "\n".join(
                 "{:3s} {}".format(
                     vote.point if self.revealed else vote.masked, user_id
                 )
                 for user_id, vote in sorted(self.votes.items())
             )
-            result += "\n\nCurrent votes:\n{}".format(votes_str)
+            result += "\n\nCurrent votes ({} participants):\n{}".format(vote_count, votes_str)
         return result
 
     def get_send_kwargs(self):


### PR DESCRIPTION
This pull request enhances the get_text method by including the count of participants who have voted. The aim is to provide clearer and more comprehensive information about the voting state. This change aids users in quickly understanding how many people have participated in the vote.

Key Changes:
- Introduced a vote_count variable to calculate the number of users who have cast a vote.
- Updated the output format to include the number of participants alongside the list of current votes.
  
Benefits:  
- Users receive immediate feedback on how many people have participated in the voting process.
- Improves the readability and usefulness of the output displayed to users.
